### PR TITLE
Remove references to docker build

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,15 +39,6 @@ You can run the MAGICL tests from your Lisp REPL with:
 (asdf:test-system :magicl)
 ```
 
-This repository is also set up with Sempahore CI, and uses Docker for building MAGICL and running its tests. You can emulate Semaphore's behavior by using the following commands from the top-level directory:
-
-```bash
-make -C docker
-make -C docker test
-```
-
-Note, doing this requires that you have `docker` installed on your machine.
-
 ## Showing Available Functions
 
 Some distributions of a library don't actually provide all of the functions of the reference BLAS and LAPACK. One can look at a summary of available and unavailable functions with the function `magicl:print-availability-report`. By default, it will show all functions and their availability. There are three arguments to fine-tune this behavior:


### PR DESCRIPTION
The docker subdirectory was removed in the following commit, but the README still mentions running `make -C docker`.

https://github.com/rigetti/magicl/commit/9228099ab7cc079c2c737cff43a78c1260e0f356