### PR TITLE
support Allegro CL

### DIFF
--- a/src/with-array-pointers.lisp
+++ b/src/with-array-pointers.lisp
@@ -92,7 +92,8 @@ WARNING: Do not close over these pointers or otherwise store them outside of the
                   :for g := (gensym "VECTOR-STORAGE-")
                   :do (setf form
                             `(excl:with-underlying-simple-vector (,e ,g)
-                               (let ((,s (ff:fslot-address-typed :unsigned-char :lisp ,g)))
-                                 (declare (ignorable ,s))
-                                 ,form)))
+                               (excl:with-pinned-objects (,g)
+                                 (let ((,s (ff:fslot-address-typed :unsigned-char :lisp ,g)))
+                                   (declare (ignorable ,s))
+                                   ,form))))
                   :finally (return form))))))


### PR DESCRIPTION
This is the start to supporting Allegro CL. One big question I have is: Must I pin the vector storage? If I do
```
(excl:with-pinned-objects (,g) ...)
```
after `g` is created, then I get an error:
```
found non-atomic quad when atomicity required, quad =
(CALL FSLOT-ADDRESS-TYPED  ({380} {381} {379})
    -> ({378}))
```

In any case, at minimum, this patch allows magicl to compile.