### PR TITLE
Change behavior of RANDOM-GAUSSIAN-MATRIX

### DIFF
--- a/src/high-level/high-level.lisp
+++ b/src/high-level/high-level.lisp
@@ -659,6 +659,17 @@ it must be that KA = KB, and the resulting matrix is M x N."
                 (ref m (+ rmin i) (+ cmin j)))))
       (make-matrix :rows sliced-rows :cols sliced-cols :data v))))
 
+(defun matrix-column (m c)
+  "Get the column of M at index C."
+  (slice m
+         0 (matrix-rows m)
+         c (1+ c)))
+
+(defun matrix-row (m r)
+  "Get the row of M at index R."
+  (slice m
+         r (1+ r)
+         0 (matrix-cols m)))
 
 (defun csd (x p q)
   "Find the Cosine-Sine Decomposition of a matrix X given that it is to be partitioned with upper left block of dimension P-by-Q. Returns the CSD elements (VALUES U SIGMA VT) such that X=U*SIGMA*VT."

--- a/src/high-level/random.lisp
+++ b/src/high-level/random.lisp
@@ -14,12 +14,12 @@
               (complex (random 1.0d0) (random 1.0d0)))))
 
 (defun random-gaussian-matrix (rows cols)
-  "Create a Z matrix of size ROWS x COLS with normally distributed random complex entries in [0,1) + [0,1)i."
+  "Create a Z matrix of size ROWS x COLS with normally distributed random complex entries."
   (tabulate rows cols
             (lambda (i j)
               (declare (ignore i j))
-              (complex (alexandria:gaussian-random 0.0d0 1.0d0)
-                       (alexandria:gaussian-random 0.0d0 1.0d0)))))
+              (complex (alexandria:gaussian-random)
+                       (alexandria:gaussian-random)))))
 
 (defun random-unitary (n)
   "Generate a uniformly random element of U(n)."

--- a/src/packages.lisp
+++ b/src/packages.lisp
@@ -62,9 +62,13 @@
            #:print-availability-report
            #:with-blapack
            #:make-complex-matrix
+           #:make-complex-vector
            #:conjugate-entrywise
            #:transpose
            #:conjugate-transpose
+           #:slice
+           #:matrix-column
+           #:matrix-row
            #:qr
            #:ql
            #:rq


### PR DESCRIPTION
This changes the behavior of RANDOM-GAUSSIAN-MATRIX. The previous implementation did not create a random gaussian matrix: for example, the distribution did not have a rotational symmetry (since the entries are all nonnegative). As a side note, the existence of min/max optional arguments to ALEXANDRIA:GAUSSIAN-RANDOM is bad design on their part since they look like mean/variance in code.

This change impacts other random matrices, e.g. the random unitaries which are also not quite random (since the QR factorization inherits the first unit column up to scale in the Q matrix from the first column of the gaussian matrix). As a result, this change breaks one of the state prep tests in quilc, but I have an easy fix lined up.

Since we're here, I'm also hoping to export a few more things from the package.