### PR TITLE
Simplify MULTIPLY-COMPLEX-MATRIX. Cons less, compute more.

### DIFF
--- a/src/high-level/high-level.lisp
+++ b/src/high-level/high-level.lisp
@@ -378,29 +378,15 @@ it must be that KA = KB, and the resulting matrix is M x N."
         (n  (matrix-cols mb)))
     (assert (= ka kb) ()
             "Matrix A has ~D columns while matrix B has ~D rows" ka kb)
-    (let ((a (copy-matrix-storage (matrix-data ma)))
-          (b (copy-matrix-storage (matrix-data mb))))
-      (if (= n 1)
-          ;; mb is a column vector
-          (if (= m 1)
-              ;; ma is a row vector
-              ;; use dot product
-              (make-complex-matrix 1 1 (list (magicl.blas-cffi::%zdotu ka a 1 b 1)))
-              ;; use matrix-vector multiplication
-              (let ((trans "N")
-                    (alpha #C(1.0d0 0.0d0))
-                    (beta #C(0.0d0 0.0d0))
-                    (y (make-Z-storage (* m n))))
-                (magicl.blas-cffi::%zgemv trans m ka alpha a m b 1 beta y 1)
-                (make-matrix :rows m :cols n :data y)))
-          ;; use matrix-matrix multiplication
-          (let ((transa "N")
-                (transb "N")
-                (alpha #C(1.0d0 0.0d0))
-                (beta #C(0.0d0 0.0d0))
-                (c (make-Z-storage (* m n))))
-            (magicl.blas-cffi::%zgemm transa transb m n ka alpha a m b kb beta c m)
-            (make-matrix :rows m :cols n :data c))))))
+    (let ((a (matrix-data ma))
+          (b (matrix-data mb))
+          (transa "N")
+          (transb "N")
+          (alpha #C(1.0d0 0.0d0))
+          (beta #C(0.0d0 0.0d0))
+          (c (make-Z-storage (* m n))))
+      (magicl.blas-cffi::%zgemm transa transb m n ka alpha a m b kb beta c m)
+      (make-matrix :rows m :cols n :data c))))
 
 (defun conjugate-entrywise (m)
   "Computes the conjugate of each entry of matrix M."


### PR DESCRIPTION
As promised in #54, here is a patch that makes `multiply-complex-matrix` two orders of magnitude faster and less memory-hungry (see results below).

```lisp
(in-package #:magicl)

(defparameter *n* 2048)
(defparameter *matrix* (magicl:random-unitary *n*))
(defparameter *vector* (magicl:random-matrix *n* 1))

(progn
  (sb-ext:gc :full t)
  (dotimes (i 3)
    (time (multiply-complex-matrices *matrix* *vector*))))

(format t "===================================~%")

(progn
  (sb-ext:gc :full t)
  (dotimes (i 3)
    (time (multiply-complex-matrices-old *matrix* *vector*))))

;;; WITH THIS PATCH.
;; Evaluation took:
;;   0.005 seconds of real time
;;   0.017629 seconds of total run time (0.017518 user, 0.000111 system)
;;   360.00% CPU
;;   12,243,972 processor cycles
;;   1,840 bytes consed
;;   
;; Evaluation took:
;;   0.003 seconds of real time
;;   0.011476 seconds of total run time (0.011374 user, 0.000102 system)
;;   366.67% CPU
;;   8,130,614 processor cycles
;;   39,808 bytes consed
;;   
;; Evaluation took:
;;   0.003 seconds of real time
;;   0.011497 seconds of total run time (0.011432 user, 0.000065 system)
;;   366.67% CPU
;;   7,961,397 processor cycles
;;   38,672 bytes consed
;;   
;;; WITH THE PREVIOUS VERSION OF THE CODE:
;; ===================================
;; Evaluation took:
;;   0.038 seconds of real time
;;   0.077195 seconds of total run time (0.063205 user, 0.013990 system)
;;   [ Run times consist of 0.003 seconds GC time, and 0.075 seconds non-GC time. ]
;;   202.63% CPU
;;   104,146,258 processor cycles
;;   67,143,712 bytes consed
;;   
;; Evaluation took:
;;   0.043 seconds of real time
;;   0.082063 seconds of total run time (0.065534 user, 0.016529 system)
;;   [ Run times consist of 0.003 seconds GC time, and 0.080 seconds non-GC time. ]
;;   190.70% CPU
;;   116,569,989 processor cycles
;;   67,141,680 bytes consed
;;   
;; Evaluation took:
;;   0.020 seconds of real time
;;   0.046819 seconds of total run time (0.046032 user, 0.000787 system)
;;   [ Run times consist of 0.003 seconds GC time, and 0.044 seconds non-GC time. ]
;;   235.00% CPU
;;   53,982,880 processor cycles
;;   67,141,680 bytes consed
```
