### PR TITLE
Faster CS decomposition for equipartitioned 2x2 unitary matrices.

### DIFF
--- a/src/high-level/high-level.lisp
+++ b/src/high-level/high-level.lisp
@@ -795,34 +795,33 @@ with upper left block with dimension P-by-Q. Returns the intermediate representa
          (a1 (aref data 0))
          (a2 (aref data 1))
          (a3 (aref data 2))
-         (a4 (aref data 3)))
+         (a4 (aref data 3))
 
-    (let ((c (abs a1))
-          (u1 (cis (phase a1)))
-          (s (abs a2))
-          (u2 (cis (phase a2))))
+         (c (abs a1))
+         (u1 (cis (phase a1)))
+         (s (abs a2))
+         (u2 (cis (phase a2))))
 
-      (declare (type (double-float -1.0d0 1.0d0) c s)
-               (type (complex double-float) u1 u2)
-               (dynamic-extent c s u1 u2))
+    (declare (type (double-float -1.0d0 1.0d0) c s)
+             (type (complex double-float) u1 u2)
+             (dynamic-extent c s u1 u2))
 
-      (let ((v2h (conjugate (/ 1.0d0 (- (* c (conjugate u2) a4)
-                                        (* s (conjugate u1) a3))))))
+    (let ((v2h (conjugate (/ 1.0d0 (- (* c (conjugate u2) a4)
+                                      (* s (conjugate u1) a3)))))
+          (mu1 (make-zero-matrix 1 1))
+          (mu2 (make-zero-matrix 1 1))
+          (mv1h (make-zero-matrix 1 1))
+          (mv2h (make-zero-matrix 1 1)))
 
-        (let ((mu1 (make-zero-matrix 1 1))
-              (mu2 (make-zero-matrix 1 1))
-              (mv1h (make-zero-matrix 1 1))
-              (mv2h (make-zero-matrix 1 1)))
+      (macrolet ((matrix-1x1-data (matrix)
+                   `(the (complex-matrix-data 1) (matrix-data ,matrix))))
 
-          (macrolet ((matrix-1x1-data (matrix)
-                       `(the (complex-matrix-data 1) (matrix-data ,matrix))))
+        (setf (aref (matrix-1x1-data mu1) 0) u1
+              (aref (matrix-1x1-data mu2) 0) u2
+              (aref (matrix-1x1-data mv1h) 0) #c(1.0d0 0.0d0)
+              (aref (matrix-1x1-data mv2h) 0) v2h))
 
-            (setf (aref (matrix-1x1-data mu1) 0) u1
-                  (aref (matrix-1x1-data mu2) 0) u2
-                  (aref (matrix-1x1-data mv1h) 0) #c(1.0d0 0.0d0)
-                  (aref (matrix-1x1-data mv2h) 0) v2h))
-
-          (values mu1 mu2 mv1h mv2h (list (atan s c))))))))
+      (values mu1 mu2 mv1h mv2h (list (atan s c))))))
 
 ;;; TODO FIXME
 (defun lisp-zlacpy (UPLO M N A rows-a B rows-b &optional (offx 0) (offy 0))

--- a/src/high-level/high-level.lisp
+++ b/src/high-level/high-level.lisp
@@ -782,16 +782,16 @@ with upper left block with dimension P-by-Q. Returns the intermediate representa
 (defun csd-2x2-basic (unitary-matrix-2x2 p q)
   "Returns the Cosine-Sine decomposition of an equipartitioned UNITARY-MATRIX-2x2. The values of P and Q are assumed to be equal to one and ignored. See the documentation of LAPACK-CSD for details about the returned values."
   ;; This function is meant to be used within LAPACK-CSD in the base case
-  ;; where the unitary matrix is 2x2. It computes the CS decomposition in
-  ;; Lisp and does it faster (more than three times) and with less memory
-  ;; overhead (conses less than half as much) than the LAPACK routine.
+  ;; where the unitary matrix is 2x2 (i.e., it is equivalent to a ZYZ
+  ;; decomposition). It computes the CS decomposition in Lisp faster (more
+  ;; than three times) and with less memory overhead (conses less than half
+  ;; as much) than the corresponding LAPACK wrapper.
   (declare (type matrix unitary-matrix-2x2)
            (values matrix matrix matrix matrix list)
            (ignorable p q)
            (optimize (speed 3) (safety 0) (debug 0) (space 0)))
 
-  (let* ((data (the (complex-matrix-data 4)
-                    (magicl::matrix-data unitary-matrix-2x2)))
+  (let* ((data (matrix-data unitary-matrix-2x2))
          (a1 (aref data 0))
          (a2 (aref data 1))
          (a3 (aref data 2))
@@ -802,7 +802,8 @@ with upper left block with dimension P-by-Q. Returns the intermediate representa
          (s (abs a2))
          (u2 (cis (phase a2))))
 
-    (declare (type (double-float -1.0d0 1.0d0) c s)
+    (declare (type (complex-matrix-data 4) data)
+             (type (double-float -1.0d0 1.0d0) c s)
              (type (complex double-float) u1 u2)
              (dynamic-extent c s u1 u2))
 

--- a/tests/high-level-tests.lisp
+++ b/tests/high-level-tests.lisp
@@ -121,3 +121,16 @@
     (let ((short-fat-matrix (random-matrix 2 8)))
       (check-full-svd short-fat-matrix)
       (check-reduced-svd short-fat-matrix))))
+
+(deftest test-csd-2x2-basic ()
+  "Test CS decomposition of an equipartitioned 2x2 unitary matrix."
+  (let ((x (magicl:random-unitary 2)))
+    (multiple-value-bind (u1 u2 v1h v2h theta)
+        (magicl::csd-2x2-basic x 1 1)
+      (multiple-value-bind (u1* u2* v1h* v2h* theta*)
+          (lapack-csd x 1 1)
+        (is (< (abs (- (ref u1 0 0) (ref u1* 0 0))) 1.0d-15))
+        (is (< (abs (- (ref u2 0 0) (ref u2* 0 0))) 1.0d-15))
+        (is (< (abs (- (ref v1h 0 0) (ref v1h* 0 0))) 1.0d-15))
+        (is (< (abs (- (ref v2h 0 0) (ref v2h* 0 0))) 1.0d-15))
+        (is (< (abs (- (first theta) (first theta*))) 1.0d-15))))))

--- a/tests/high-level-tests.lisp
+++ b/tests/high-level-tests.lisp
@@ -5,6 +5,8 @@
 
 (in-package #:magicl-tests)
 
+(defconstant +double-float-epsilon+ #+sbcl sb-c::double-float-epsilon #-sbcl 1.1102230246251568d-16)
+
 (deftest test-determinant ()
   "Test that DET works."
   (let* ((x (magicl::make-complex-matrix 3 3 (list 6 4 2 1 -2 8 1 5 7)))
@@ -84,7 +86,7 @@
              (let ((data (magicl::matrix-data matrix)))
                (reduce #'max data :key #'abs)))
 
-           (zero-p (matrix &optional (tolerance 1.0e-14))
+           (zero-p (matrix &optional (tolerance (* 1.0d2 +double-float-epsilon+)))
              "Return T if MATRIX is close to zero (within TOLERANCE)."
              (< (norm-inf matrix) tolerance))
 
@@ -124,13 +126,14 @@
 
 (deftest test-csd-2x2-basic ()
   "Test CS decomposition of an equipartitioned 2x2 unitary matrix."
-  (let ((x (magicl:random-unitary 2)))
+  (let ((x (magicl:random-unitary 2))
+        (tol (* 1.0d2 +double-float-epsilon+)))
     (multiple-value-bind (u1 u2 v1h v2h theta)
         (magicl::csd-2x2-basic x 1 1)
       (multiple-value-bind (u1* u2* v1h* v2h* theta*)
           (lapack-csd x 1 1)
-        (is (< (abs (- (ref u1 0 0) (ref u1* 0 0))) 1.0d-15))
-        (is (< (abs (- (ref u2 0 0) (ref u2* 0 0))) 1.0d-15))
-        (is (< (abs (- (ref v1h 0 0) (ref v1h* 0 0))) 1.0d-15))
-        (is (< (abs (- (ref v2h 0 0) (ref v2h* 0 0))) 1.0d-15))
-        (is (< (abs (- (first theta) (first theta*))) 1.0d-15))))))
+        (is (< (abs (- (ref u1 0 0) (ref u1* 0 0))) tol))
+        (is (< (abs (- (ref u2 0 0) (ref u2* 0 0))) tol))
+        (is (< (abs (- (ref v1h 0 0) (ref v1h* 0 0))) tol))
+        (is (< (abs (- (ref v2h 0 0) (ref v2h* 0 0))) tol))
+        (is (< (abs (- (first theta) (first theta*))) tol))))))


### PR DESCRIPTION
This implements the CS decomposition in the base case of an equipartitioned 2x2 unitary matrix.

The function `csd-2x2-basic` is significantly faster and less memory-hungry than the call to `lapack-csd` as shown below:

```lisp
MAGICL> (let ((p 1)
              (q 1)
              (u (magicl:random-unitary 2)))

          (sb-ext:gc :full t)

          (time
           (dotimes (i 100000)
             (when (= p q 1)
               (csd-2x2-basic u p q))))

          (sb-ext:gc :full t)
           
          (time
           (dotimes (i 100000)
             (lapack-csd u p q))))
Evaluation took:
  0.144 seconds of real time
  0.143749 seconds of total run time (0.130993 user, 0.012756 system)
  [ Run times consist of 0.003 seconds GC time, and 0.141 seconds non-GC time. ]
  100.00% CPU
  390,120,550 processor cycles
  103,980,336 bytes consed
  
Evaluation took:
  0.507 seconds of real time
  0.506777 seconds of total run time (0.488778 user, 0.017999 system)
  [ Run times consist of 0.014 seconds GC time, and 0.493 seconds non-GC time. ]
  100.00% CPU
  1,376,727,302 processor cycles
  246,394,256 bytes consed
```