### PR TITLE
Do not export expm symbol from magicl package

### DIFF
--- a/examples.lisp
+++ b/examples.lisp
@@ -1,5 +1,5 @@
 (defpackage #:magicl-examples
-  (:use #:common-lisp #:magicl)
+  (:use #:common-lisp #:magicl #:magicl-transcendental)
   #+package-local-nicknames
   (:local-nicknames (:blas :magicl.blas-cffi)
                     (:lapack :magicl.lapack-cffi)

--- a/magicl-examples.asd
+++ b/magicl-examples.asd
@@ -3,7 +3,7 @@
   :description "MAGICL examples"
   :maintainer "Rigetti Computing"
   :author "Rigetti Computing"
-  :depends-on (#:magicl)
+  :depends-on (#:magicl #:magicl-transcendental)
   :serial t
   :components
   ((:file "examples")))

--- a/src/packages.lisp
+++ b/src/packages.lisp
@@ -85,7 +85,6 @@
            #:direct-sum
            #:diag
            #:matrix-diagonal
-           #:expm
            #:eig
            #:hermitian-eig
            #:logm


### PR DESCRIPTION
The `expm` symbol exists in the `magicl-transcendental` package instead.