### PR TITLE
Implement LAYOUT method for vectors so that we can SLICE them

### DIFF
--- a/src/high-level/vector.lisp
+++ b/src/high-level/vector.lisp
@@ -12,6 +12,9 @@
                    (:copier nil))
   (size 0 :type alexandria:positive-fixnum))
 
+(defmethod layout ((v vector))
+  :row-major)
+
 (defmacro defvector (name type tensor-class)
   "Define a new vector subclass with the specified NAME and element TYPE,
 compatible with TENSOR-CLASS, as well as the abstract-tensor methods


### PR DESCRIPTION
Without this, `(let ((v (ones '(10)))) (slice v '(0) '(3)))` won't work.