### PR TITLE
Add abstract-classes to magicl-gen

### DIFF
--- a/magicl-gen.asd
+++ b/magicl-gen.asd
@@ -7,7 +7,8 @@
   :description "Generate MAGICL interfaces"
   :maintainer "Rigetti Computing"
   :author "Rigetti Computing"
-  :depends-on (#:cffi
+  :depends-on (#:abstract-classes
+               #:cffi
                #:cffi-libffi)
   :serial t
   :components


### PR DESCRIPTION
Requirement was added for magicl in
a37039a8537dabb0095306b8e463c7aca9b4c5c9, needs to be reflected in
magicl-gen as well, since they share src/packages.lisp