### PR TITLE
Add matrix-vector multiplication

### DIFF
--- a/src/high-level/lapack-bindings.lisp
+++ b/src/high-level/lapack-bindings.lisp
@@ -10,6 +10,7 @@
                 ,@(loop :for type :in '(single-float double-float (complex single-float) (complex double-float))
                         :for real-type :in (list nil nil 'single-float 'double-float)
                         :for matrix-class :in '(matrix/single-float matrix/double-float matrix/complex-single-float matrix/complex-double-float)
+                        :for vector-class :in '(vector/single-float vector/double-float vector/complex-single-float vector/complex-double-float)
                         :for prefix :in '("s" "d" "c" "z")
                         :append
                         (labels ((generate-routine-symbol (package routine)
@@ -21,8 +22,8 @@
                           (let ((complex (not (null real-type))))
                             (list
                              (generate-lapack-mult-for-type
-                              matrix-class type
-                              (blas-routine "gemm"))
+                              matrix-class vector-class type
+                              (blas-routine "gemm") (blas-routine "gemv"))
                              (generate-lapack-lu-for-type
                               matrix-class type (lapack-routine "getrf"))
                              (generate-lapack-inv-for-type

--- a/src/high-level/lapack-generics.lisp
+++ b/src/high-level/lapack-generics.lisp
@@ -4,6 +4,10 @@
 
 (in-package #:magicl)
 
+(defgeneric mult (a b &key target alpha beta transa transb)
+  (:documentation "Multiply a by b, storing in target or creating a new tensor if target is not specified.
+Target cannot be the same as a or b."))
+
 (defgeneric lapack-eig (matrix))
 
 (defgeneric lapack-hermitian-eig (matrix))

--- a/src/high-level/lapack-generics.lisp
+++ b/src/high-level/lapack-generics.lisp
@@ -6,7 +6,11 @@
 
 (defgeneric lapack-eig (matrix))
 
+(defgeneric lapack-hermitian-eig (matrix))
+
 (defgeneric lapack-lu (matrix))
+
+(defgeneric lapack-inv (matrix))
 
 (defgeneric lapack-csd (matrix p q))
 

--- a/src/high-level/lapack-templates.lisp
+++ b/src/high-level/lapack-templates.lisp
@@ -61,9 +61,9 @@
                 m)
                target)))))
      (defmethod mult ((a ,matrix-class) (x ,vector-class) &key target (alpha ,(coerce 1 type)) (beta ,(coerce 0 type)) (transa :n) transb)
-       (declare (ignore transb))
        (policy-cond:with-expectations (> speed safety)
-           ((type (member nil :n :t :c) transa))
+           ((type (member nil :n :t :c) transa)
+            (assertion (null transb)))
          (let* ((m-op (if (eq :n transa) (nrows a) (ncols a)))
                 (n-op (if (eq :n transa) (ncols a) (nrows a))))
            (policy-cond:with-expectations (> speed safety)
@@ -89,7 +89,7 @@
                 (if (eql :column-major (layout a)) (ncols a) (nrows a))
                 alpha
                 (storage a)
-                (if (eql :n ta) (ncols a) (nrows a))
+                (if (eql :column-major (layout a)) (nrows a) (ncols a))
                 (storage x)
                 1 ;; NOTE: This corresponds to the stride of X
                 beta

--- a/src/high-level/matrix.lisp
+++ b/src/high-level/matrix.lisp
@@ -286,10 +286,6 @@ ELEMENT-TYPE, CAST, COPY-TENSOR, DEEP-COPY-TENSOR, TREF, SETF TREF)"
            (list 0 index)
            (list (nrows m) (1+ index)))))
 
-(defgeneric mult (a b &key target alpha beta transa transb)
-  (:documentation "Multiply matrix a by matrix b, storing in target or creating a new matrix if target is not specified.
-Target cannot be the same as a or b."))
-
 (defgeneric @ (matrix &rest matrices)
     (:documentation "Multiplication of matrices")
   (:method (matrix &rest matrices)

--- a/src/high-level/vector.lisp
+++ b/src/high-level/vector.lisp
@@ -12,6 +12,9 @@
                    (:copier nil))
   (size 0 :type alexandria:positive-fixnum))
 
+(defmethod size ((m vector))
+  (vector-size m))
+
 (defmethod layout ((v vector))
   :row-major)
 

--- a/tests/matrix-tests.lisp
+++ b/tests/matrix-tests.lisp
@@ -14,18 +14,18 @@
 
 (deftest test-identity-matrix-p ()
   "Test that identity matrices can be identified by IDENTITY-MATRIX-P for all types of matrixes from 1x1 to 64x64"
-  (loop :for i :from 1 :to 64
-        :do (loop :for type :in +magicl-types+
-                  :do (is (magicl:identity-matrix-p (magicl:eye (list i i) :type type)))
-                      (is (not (magicl:identity-matrix-p (magicl:eye (list i i) :value 2 :type type))))
-                      (is (not (magicl:identity-matrix-p (magicl:const 0 (list i i) :type type)))))))
+  (dolist (type +magic-types+)
+    (loop :for i :from 1 :to 64 :do
+      (is (magicl:identity-matrix-p (magicl:eye (list i i) :type type)))
+      (is (not (magicl:identity-matrix-p (magicl:eye (list i i) :value 2 :type type))))
+      (is (not (magicl:identity-matrix-p (magicl:const 0 (list i i) :type type)))))))
 
 (deftest test-square-matrix-p ()
   "Test that square matrices can be identified by IDENTITY-MATRIX-P for all types of matrixes from 1x1 to 64x64"
-  (loop :for i :from 1 :to 64
-        :do (loop :for type :in +magicl-types+
-                  :do (is (magicl:square-matrix-p (magicl:empty (list i i) :type type)))
-                      (is (not (magicl:square-matrix-p (magicl:empty (list i (* 2 i)) :type type)))))))
+  (dolist (type +magicl-types+)
+    (loop :for i :from 1 :to 64 :do
+      (is (magicl:square-matrix-p (magicl:empty (list i i) :type type)))
+      (is (not (magicl:square-matrix-p (magicl:empty (list i (* 2 i)) :type type)))))))
 
 ;; Multiplication
 
@@ -37,43 +37,41 @@
                     (n (magicl:ncols b))
                     (p (magicl:ncols a))
                     (target (magicl:empty (list m n))))
-               (loop :for i :below m
-                     :do (loop :for j :below n
-                               :do (setf (magicl:tref target i j)
-                                         (loop :for k :below p
-                                               :sum (* (magicl:tref a i k)
-                                                       (magicl:tref b k j))))))
+               (loop :for i :below m :do
+                 (loop :for j :below n :do
+                   (setf (magicl:tref target i j)
+                         (loop :for k :below p
+                               :sum (* (magicl:tref a i k)
+                                       (magicl:tref b k j))))))
                target)))
-    (loop :for magicl::*default-tensor-type* :in +magicl-float-types+
-          :do
-             (loop :for i :below 1000
-                   :do
-                      (let* ((n (1+ (random 5)))
-                             (m (1+ (random 5)))
-                             (k (1+ (random 5)))
-                             (a (magicl:rand (list m k)))
-                             (b (magicl:rand (list k n)))
-                             (c (magicl:rand (list m n))))
-                        ;; Check that multiplication returns the correct result
-                        (is (magicl:=
-                             (mult a b)
-                             (magicl:mult a b)))
+    (dolist (magicl::*default-tensor-type* +magicl-float-types+)
+      (loop :for i :below 1000 :do
+        (let* ((n (1+ (random 5)))
+               (m (1+ (random 5)))
+               (k (1+ (random 5)))
+               (a (magicl:rand (list m k)))
+               (b (magicl:rand (list k n)))
+               (c (magicl:rand (list m n))))
+          ;; Check that multiplication returns the correct result
+          (is (magicl:=
+               (mult a b)
+               (magicl:mult a b)))
 
-                        ;; Check that transposing doesn't affect correctness
-                        (is (magicl:=
-                             (mult (magicl:transpose a) c)
-                             (magicl:mult a c :transa :t)))
-                        (is (magicl:=
-                             (mult b (magicl:transpose c))
-                             (magicl:mult b c :transb :t)))
-                        (is (magicl:=
-                             (mult (magicl:transpose b) (magicl:transpose a))
-                             (magicl:mult b a :transa :t :transb :t)))
+          ;; Check that transposing doesn't affect correctness
+          (is (magicl:=
+               (mult (magicl:transpose a) c)
+               (magicl:mult a c :transa :t)))
+          (is (magicl:=
+               (mult b (magicl:transpose c))
+               (magicl:mult b c :transb :t)))
+          (is (magicl:=
+               (mult (magicl:transpose b) (magicl:transpose a))
+               (magicl:mult b a :transa :t :transb :t)))
 
-                        ;; Check that alpha correctly scales the matrices
-                        (is (magicl:=
-                             (mult (magicl:scale a 2) b)
-                             (magicl:mult a b :alpha (coerce 2 magicl::*default-tensor-type*)))))))))
+          ;; Check that alpha correctly scales the matrices
+          (is (magicl:=
+               (mult (magicl:scale a 2) b)
+               (magicl:mult a b :alpha (coerce 2 magicl::*default-tensor-type*)))))))))
 
 (deftest test-matrix-vector-multiplication ()
   "Test multiplication for random pairs of matrix and vectors"
@@ -82,36 +80,34 @@
              (let* ((m (magicl:nrows a))
                     (n (magicl:ncols a))
                     (target (magicl:empty (list m))))
-               (loop :for i :below m
-                     :do (setf (magicl:tref target i)
-                               (loop :for k :below n
-                                     :sum (* (magicl:tref a i k)
-                                             (magicl:tref x k)))))
+               (loop :for i :below m :do
+                 (setf (magicl:tref target i)
+                       (loop :for k :below n
+                             :sum (* (magicl:tref a i k)
+                                     (magicl:tref x k)))))
                target)))
-    (loop :for magicl::*default-tensor-type* :in +magicl-float-types+
-          :do
-             (loop :for i :below 1000
-                   :do
-                      (let* ((n (1+ (random 5)))
-                             (m (1+ (random 5)))
-                             (a (magicl:rand (list m n)))
-                             (x (magicl:rand (list n)))
-                             (y (magicl:rand (list m))))
+    (dolist (magicl::*default-tensor-type* +magicl-float-types+)
+      (loop :for i :below 1000 :do
+        (let* ((n (1+ (random 5)))
+               (m (1+ (random 5)))
+               (a (magicl:rand (list m n)))
+               (x (magicl:rand (list n)))
+               (y (magicl:rand (list m))))
 
-                        ;; Check that multiplication returns the correct result
-                        (is (magicl:=
-                             (mult a x)
-                             (magicl:mult a x)))
+          ;; Check that multiplication returns the correct result
+          (is (magicl:=
+               (mult a x)
+               (magicl:mult a x)))
 
-                        ;; Check that transposing doesn't affect correctness
-                        (is (magicl:=
-                             (mult (magicl:transpose a) y)
-                             (magicl:mult a y :transa :t)))
+          ;; Check that transposing doesn't affect correctness
+          (is (magicl:=
+               (mult (magicl:transpose a) y)
+               (magicl:mult a y :transa :t)))
 
-                        ;; Check that alpha correctly scales the matrices
-                        (is (magicl:=
-                             (mult (magicl:scale a 2) x)
-                             (magicl:mult a x :alpha (coerce 2 magicl::*default-tensor-type*)))))))))
+          ;; Check that alpha correctly scales the matrices
+          (is (magicl:=
+               (mult (magicl:scale a 2) x)
+               (magicl:mult a x :alpha (coerce 2 magicl::*default-tensor-type*)))))))))
 
 (deftest test-matrix-multiplication-errors ()
   (signals simple-error (magicl:@
@@ -144,13 +140,13 @@
 
 (deftest test-random-unitary-properties ()
   "Test calls to RANDOM-UNITARY for all float types and sizes 1x1 to 64x64 to check properties"
-  (loop :for type :in +magicl-float-types+
-        :do (loop :for i :from 1 :to 64
-                  :do (let ((m (magicl:random-unitary (list i i) :type type)))
-                        (is (> 5e-5 (abs (cl:-
-                                          (abs (magicl:det m))
-                                          1))))
-                        (is (magicl:=
-                             (magicl:eye (list i i) :type type)
-                             (magicl:@ m (magicl:transpose m))
-                             5e-5))))))
+  (dolist (type +magicl-float-types+)
+    (loop :for i :from 1 :to 64 :do
+      (let ((m (magicl:random-unitary (list i i) :type type)))
+        (is (> 5e-5 (abs (cl:-
+                          (abs (magicl:det m))
+                          1))))
+        (is (magicl:=
+             (magicl:eye (list i i) :type type)
+             (magicl:@ m (magicl:transpose m))
+             5e-5))))))


### PR DESCRIPTION
Adds lapack-based matrix-vector multiplication for supported types and overhauls lapack high-level binding generation. These bindings support all the same options that a normal matrix-matrix `mult` does including scaling, transposing, and accounting for layout of supplied matrix.

The main issue I have with reusing `mult` here is that there is an unused parameter of `transb`.

See #82 