### PR TITLE
Loosen float comparison thresholds

### DIFF
--- a/examples.lisp
+++ b/examples.lisp
@@ -16,8 +16,6 @@
 
 (in-package #:magicl-examples)
 
-(defconstant +double-comparison-threshold-loose+ (* 256 double-float-epsilon))
-
 (defun print-matrix (m)
   (princ m)
   (terpri)
@@ -63,7 +61,7 @@
     (format t "R~%~a~%" r)
     (let ((a-reconst (magicl:@ q r)))
       (format t "Reconstructed A~%~a~%" a-reconst)
-      (assert (magicl:= a a-reconst +double-comparison-threshold-loose+)))))
+      (assert (magicl:= a a-reconst)))))
 
 (defun ql-printing (a)
   (multiple-value-bind (q l)
@@ -73,7 +71,7 @@
     (format t "L~%~a~%" l)
     (let ((a-reconst (magicl:@ q l)))
       (format t "Reconstructed A~%~a~%" a-reconst)
-      (assert (magicl:= a a-reconst +double-comparison-threshold-loose+)))))
+      (assert (magicl:= a a-reconst)))))
 
 (defun rq-printing (a)
   (multiple-value-bind (q r)
@@ -83,7 +81,7 @@
     (format t "R~%~a~%" r)
     (let ((a-reconst (magicl:@ r q)))
       (format t "Reconstructed A~%~a~%" a-reconst)
-      (assert (magicl:= a a-reconst +double-comparison-threshold-loose+)))))
+      (assert (magicl:= a a-reconst)))))
 
 (defun lq-printing (a)
   (multiple-value-bind (q l)
@@ -93,7 +91,7 @@
     (format t "L~%~a~%" l)
     (let ((a-reconst (magicl:@ l q)))
       (format t "Reconstructed A~%~a~%" a-reconst)
-      (assert (magicl:= a a-reconst +double-comparison-threshold-loose+)))))
+      (assert (magicl:= a a-reconst)))))
 
 (defun svd-printing (a)
   (multiple-value-bind (u sigma vt) (magicl:svd a)

--- a/src/high-level/util.lisp
+++ b/src/high-level/util.lisp
@@ -4,8 +4,8 @@
 
 (in-package #:magicl)
 
-(defvar *float-comparison-threshold* single-float-epsilon)
-(defvar *double-comparison-threshold* double-float-epsilon)
+(defvar *float-comparison-threshold* (* 1e2 single-float-epsilon))
+(defvar *double-comparison-threshold* (* 1e2  double-float-epsilon))
 
 (defun row-major-index (pos dims)
   (declare (type index pos)


### PR DESCRIPTION
The default threshold is to strict and causes tests to fail occasionally

Resolves #85 