### PR TITLE
Optimize from-list

### DIFF
--- a/src/high-level/constructors.lisp
+++ b/src/high-level/constructors.lisp
@@ -131,13 +131,13 @@ The tensor is specialized on SHAPE and TYPE."
          (assertion (cl:= len (reduce #'* shape))))
       (let* ((tensor-class (infer-tensor-type type shape (first list)))
              (tensor (make-tensor tensor-class shape :layout layout))
-             (index-function (if (eql input-layout :row-major)
+             (index-function (if (eq input-layout ':row-major)
                                  #'from-row-major-index
                                  #'from-column-major-index)))
-        (loop :for i :below len :do
+        ;; XXX: Optimizations for rank 1 and 2 tensors should be added
+        (dotimes (i len tensor)
           (setf (apply #'tref tensor (funcall index-function i shape))
-                (pop list)))
-        tensor))))
+                (pop list)))))))
 
 (defun from-diag (list &key (order 2) type layout)
   "Create a tensor from a list, placing along the diagonal

--- a/src/high-level/constructors.lisp
+++ b/src/high-level/constructors.lisp
@@ -125,19 +125,19 @@ If INPUT-LAYOUT is not specified then row-major is assumed.
 If TYPE is not specified then it is inferred from the type of the first element of LIST.
 LAYOUT specifies the internal storage representation ordering of the returned tensor.
 The tensor is specialized on SHAPE and TYPE."
-  (policy-cond:with-expectations (> speed safety)
-      ((type shape shape)
-       (assertion (cl:= (length list) (reduce #'* shape))))
-    (let* ((tensor-class (infer-tensor-type type shape (first list)))
-           (tensor (make-tensor tensor-class shape :layout layout)))
-      (into!
-       (lambda (&rest pos)
-         (nth
-          (if (eql input-layout :row-major)
-              (row-major-index pos shape)
-              (column-major-index pos shape))
-          list))
-       tensor))))
+  (let ((len (length list)))
+    (policy-cond:with-expectations (> speed safety)
+        ((type shape shape)
+         (assertion (cl:= len (reduce #'* shape))))
+      (let* ((tensor-class (infer-tensor-type type shape (first list)))
+             (tensor (make-tensor tensor-class shape :layout layout))
+             (index-function (if (eql input-layout :row-major)
+                                 #'from-row-major-index
+                                 #'from-column-major-index)))
+        (loop :for i :below len :do
+          (setf (apply #'tref tensor (funcall index-function i shape))
+                (pop list)))
+        tensor))))
 
 (defun from-diag (list &key (order 2) type layout)
   "Create a tensor from a list, placing along the diagonal


### PR DESCRIPTION
This is a band-aid fix for #86 to optimize from-list to be O(n).

Once a central tensor registry is implemented (#95) a second path to coerce the input sequence to the correct array type (as described in #86).