### PR TITLE
Allow for multi-dimensional arrays in FROM-ARRAY constructor.

### DIFF
--- a/magicl-tests.asd
+++ b/magicl-tests.asd
@@ -23,5 +23,6 @@
                (:file "util-tests")
                (:file "abstract-tensor-tests")
                (:file "specialization-tests")
+               (:file "constructor-tests")
                (:file "matrix-tests")
                (:file "high-level-tests")))

--- a/src/high-level/constructors.lisp
+++ b/src/high-level/constructors.lisp
@@ -119,7 +119,8 @@ The tensor is specialized on TYPE with shape (floor(RANGE))."
   "Create a tensor from ARRAY, calling ADJUST-ARRAY on ARRAY to flatten to a 1-dimensional array of length equal to the product of the elements in SHAPE
 
 If TYPE is not specified then it is inferred from the element type of ARRAY.
-LAYOUT specifies the internal storage representation ordering of the returned tensor. The input is assumed to be ROW-MAJOR.
+LAYOUT specifies the internal storage representation ordering of the returned tensor.
+INPUT-LAYOUT specifies the layout of ARRAY.
 The tensor is specialized on SHAPE and TYPE."
   (policy-cond:with-expectations (> speed safety)
       ((type shape shape))

--- a/src/high-level/constructors.lisp
+++ b/src/high-level/constructors.lisp
@@ -129,13 +129,13 @@ The tensor is specialized on SHAPE and TYPE."
            (storage (make-array storage-size :element-type type))
            (array-dims (array-dimensions array)))
       (let ((index-function
-             (if (eq layout ':row-major)
-                 #'row-major-index
-                 #'column-major-index))
+              (if (eq layout ':row-major)
+                  #'row-major-index
+                  #'column-major-index))
             (input-index-function
-             (if (eq input-layout ':row-major)
-                 #'row-major-index
-                 #'column-major-index)))
+              (if (eq input-layout ':row-major)
+                  #'row-major-index
+                  #'column-major-index)))
         (cond
           ((not (cdr array-dims))
            (map-indexes

--- a/src/high-level/lapack-templates.lisp
+++ b/src/high-level/lapack-templates.lisp
@@ -178,7 +178,7 @@
               work
               lwork
               info))
-           (values a-tensor))))))
+           (values (from-array a (shape a-tensor) :input-layout :column-major)))))))
 
 (defun generate-lapack-svd-for-type (class type svd-function &optional real-type)
   `(progn
@@ -219,9 +219,9 @@
              (dotimes (i k)
                (setf (aref smat (matrix-column-major-index i i u-cols vt-rows))
                      (aref s i)))
-             (values (from-array u (list rows u-cols) :layout :column-major)
-                     (from-array smat (list u-cols vt-rows) :layout :column-major)
-                     (from-array vt (list vt-rows cols) :layout :column-major))))))))
+             (values (from-array u (list rows u-cols) :input-layout :column-major)
+                     (from-array smat (list u-cols vt-rows) :input-layout :column-major)
+                     (from-array vt (list vt-rows cols) :input-layout :column-major))))))))
 
 ;; TODO: This returns only the real parts when with non-complex numbers. Should do something different?
 (defun generate-lapack-eig-for-type (class type eig-function &optional real-type)
@@ -258,7 +258,7 @@
                ;; run it again with optimal workspace size
                (,eig-function jobvl jobvr rows a rows ,@(if real-type `(w) `(wr wi))
                               vl 1 vr rows work lwork ,@(when real-type `(rwork)) info)
-               (values (coerce ,@(if real-type `(w) `(wr)) 'list) (from-array vr (list rows cols) :layout :column-major)))))))))
+               (values (coerce ,@(if real-type `(w) `(wr)) 'list) (from-array vr (list rows cols) :input-layout :column-major)))))))))
 
 (defun generate-lapack-hermitian-eig-for-type (class type eig-function real-type)
   `(progn
@@ -400,7 +400,7 @@
            (values a-tensor
                    (from-array tau (list (min rows cols))
                                :type ',type
-                               :layout :column-major)))))
+                               :input-layout :column-major)))))
      
      (defmethod lapack-ql ((m ,class))
        (let* ((rows (nrows m))
@@ -423,7 +423,7 @@
            (values a-tensor
                    (from-array tau (list (min rows cols))
                                :type ',type
-                               :layout :column-major)))))
+                               :input-layout :column-major)))))
 
      (defmethod lapack-rq ((m ,class))
        (let* ((rows (nrows m))
@@ -446,7 +446,7 @@
            (values a-tensor
                    (from-array tau (list (min rows cols))
                                :type ',type
-                               :layout :column-major)))))
+                               :input-layout :column-major)))))
 
      (defmethod lapack-lq ((m ,class))
        (let* ((rows (nrows m))
@@ -469,7 +469,7 @@
            (values a-tensor
                    (from-array tau (list (min rows cols))
                                :type ',type
-                               :layout :column-major)))))
+                               :input-layout :column-major)))))
 
      (defmethod lapack-qr-q ((m ,class) tau)
        (let ((m (nrows m))
@@ -488,7 +488,7 @@
            (setf work (make-array (max 1 lwork) :element-type ',type))
            ;; run it again with optimal workspace size
            (,qr-q-function m n k a lda atau work lwork info)
-           (from-array a (list m k) :layout :column-major))))
+           (from-array a (list m k) :input-layout :column-major))))
 
      (defmethod lapack-ql-q ((m ,class) tau)
        (let ((m (nrows m))
@@ -506,7 +506,7 @@
            (setf work (make-array (max 1 lwork) :element-type ',type))
            ;; run it again with optimal workspace size
            (,ql-q-function m n k a lda atau work lwork info)
-           (from-array a (list m n) :layout :column-major))))
+           (from-array a (list m n) :input-layout :column-major))))
 
      (defmethod lapack-rq-q ((m ,class) tau)
        (let ((m (nrows m))
@@ -524,7 +524,7 @@
            (setf work (make-array (max 1 lwork) :element-type ',type))
            ;; run it again with optimal workspace size
            (,rq-q-function m n k a lda atau work lwork info)
-           (from-array a (list m n) :layout :column-major))))
+           (from-array a (list m n) :input-layout :column-major))))
 
      (defmethod lapack-lq-q ((m ,class) tau)
        (let ((m (nrows m))
@@ -542,4 +542,4 @@
            (setf work (make-array (max 1 lwork) :element-type ',type))
            ;; run it again with optimal workspace size
            (,lq-q-function m n k a lda atau work lwork info)
-           (from-array a (list m n) :layout :column-major))))))
+           (from-array a (list m n) :input-layout :column-major))))))

--- a/src/high-level/types/complex-double-float.lisp
+++ b/src/high-level/types/complex-double-float.lisp
@@ -188,10 +188,10 @@
                              x11 ldx11 x12 ldx12 x21 ldx21 x22 ldx22
                              theta u1 ldu1 u2 ldu2 v1t ldv1t v2t ldv2t
                              work lwork rwork lrwork iwork info)
-          (values (from-array u1 (list p p) :layout :column-major)
-                  (from-array u2 (list (- m p) (- m p)) :layout :column-major)
-                  (from-array v1t (list q q) :layout :column-major)
-                  (from-array v2t (list (- m q) (- m q)) :layout :column-major)
+          (values (from-array u1 (list p p) :input-layout :column-major)
+                  (from-array u2 (list (- m p) (- m p)) :input-layout :column-major)
+                  (from-array v1t (list q q) :input-layout :column-major)
+                  (from-array v2t (list (- m q) (- m q)) :input-layout :column-major)
                   (coerce theta 'list)))))))
 
 (defmethod csd-2x2-basic ((unitary-matrix-2x2 matrix/complex-double-float) p q)

--- a/tests/constructor-tests.lisp
+++ b/tests/constructor-tests.lisp
@@ -10,23 +10,23 @@
                  (loop :for i :from offset :below (+ offset (car dims)) :collect (coerce i type))
                  (let ((offset-step (reduce #'* (cdr dims))))
                    (loop :for i :from 1 :to (car dims)
-                      :collect (generate-list (cdr dims) (+ offset (* (1- i) offset-step))))))))
+                         :collect (generate-list (cdr dims) (+ offset (* (1- i) offset-step))))))))
     (loop :for dimensions :on '(6 5 4 3 2 1) :do
-         (dolist (input-layout '(:row-major :column-major))
-           (dolist (layout '(:row-major :column-major))
-             ;; Test n-dims to n-dims
-             (let* ((length (reduce #'* dimensions))
-                    (array (make-array dimensions :initial-contents (generate-list dimensions) :element-type 'double-float))
-                    (tensor (magicl:from-array array dimensions :layout layout :input-layout input-layout)))
-               (loop :for i :below length :do
-                    (is (= i (apply #'magicl:tref tensor (magicl::from-row-major-index i dimensions))))))
-             ;; Test 1-dim to n-dims
-             (let* ((length (reduce #'* dimensions))
-                    (array (make-array length :initial-contents (alexandria:iota length :step 1d0) :element-type 'double-float))
-                    (tensor (magicl:from-array array dimensions :layout layout :input-layout input-layout)))
-               (let ((index-function
-                      (if (eq input-layout ':row-major)
-                          #'magicl::from-row-major-index
-                          #'magicl::from-column-major-index)))
-                 (loop :for i :below length :do
-                      (is (= i (apply #'magicl:tref tensor (funcall index-function i dimensions))))))))))))
+      (dolist (input-layout '(:row-major :column-major))
+        (dolist (layout '(:row-major :column-major))
+          ;; Test n-dims to n-dims
+          (let* ((length (reduce #'* dimensions))
+                 (array (make-array dimensions :initial-contents (generate-list dimensions) :element-type 'double-float))
+                 (tensor (magicl:from-array array dimensions :layout layout :input-layout input-layout)))
+            (loop :for i :below length :do
+              (is (= i (apply #'magicl:tref tensor (magicl::from-row-major-index i dimensions))))))
+          ;; Test 1-dim to n-dims
+          (let* ((length (reduce #'* dimensions))
+                 (array (make-array length :initial-contents (alexandria:iota length :step 1d0) :element-type 'double-float))
+                 (tensor (magicl:from-array array dimensions :layout layout :input-layout input-layout)))
+            (let ((index-function
+                    (if (eq input-layout ':row-major)
+                        #'magicl::from-row-major-index
+                        #'magicl::from-column-major-index)))
+              (loop :for i :below length :do
+                (is (= i (apply #'magicl:tref tensor (funcall index-function i dimensions))))))))))))

--- a/tests/constructor-tests.lisp
+++ b/tests/constructor-tests.lisp
@@ -1,0 +1,32 @@
+;;;; constructor-tests.lisp
+;;;;
+;;;; Author: Cole Scott
+
+(in-package #:magicl-tests)
+
+(deftest test-from-array ()
+  (labels ((generate-list (dims &optional (offset 0) (type 'double-float))
+             (if (null (cdr dims))
+                 (loop :for i :from offset :below (+ offset (car dims)) :collect (coerce i type))
+                 (let ((offset-step (reduce #'* (cdr dims))))
+                   (loop :for i :from 1 :to (car dims)
+                      :collect (generate-list (cdr dims) (+ offset (* (1- i) offset-step))))))))
+    (loop :for dimensions :on '(6 5 4 3 2 1) :do
+         (dolist (input-layout '(:row-major :column-major))
+           (dolist (layout '(:row-major :column-major))
+             ;; Test n-dims to n-dims
+             (let* ((length (reduce #'* dimensions))
+                    (array (make-array dimensions :initial-contents (generate-list dimensions) :element-type 'double-float))
+                    (tensor (magicl:from-array array dimensions :layout layout :input-layout input-layout)))
+               (loop :for i :below length :do
+                    (is (= i (apply #'magicl:tref tensor (magicl::from-row-major-index i dimensions))))))
+             ;; Test 1-dim to n-dims
+             (let* ((length (reduce #'* dimensions))
+                    (array (make-array length :initial-contents (alexandria:iota length :step 1d0) :element-type 'double-float))
+                    (tensor (magicl:from-array array dimensions :layout layout :input-layout input-layout)))
+               (let ((index-function
+                      (if (eq input-layout ':row-major)
+                          #'magicl::from-row-major-index
+                          #'magicl::from-column-major-index)))
+                 (loop :for i :below length :do
+                      (is (= i (apply #'magicl:tref tensor (funcall index-function i dimensions))))))))))))

--- a/transcendental/transcendental.lisp
+++ b/transcendental/transcendental.lisp
@@ -43,7 +43,7 @@
           (dotimes (i (* rows rows))
             (setf (row-major-aref exph i)
                   (row-major-aref wsp (+ i (1- iexph)))))
-          (values (magicl:from-array exph (list rows rows) :layout :column-major)))))))
+          (values (magicl:from-array exph (list rows rows) :input-layout :column-major)))))))
 
 (defun logm (m)
   "Finds the matrix logarithm of a given square matrix M assumed to be diagonalizable, with nonzero eigenvalues"


### PR DESCRIPTION
Allows for multi-dimensional arrays as input to `FROM-ARRAY` (Resolves #102)

This also adds a new kw arg to `FROM-ARRAY`, `INPUT-LAYOUT` which allows for reindexing of input arrays (`INPUT-LAYOUT` does not need to be the same as `LAYOUT`). 

As a bonus, fixes a bug that came up while testing this PR caused by `LAPACK-INV` not setting the layout of the tensor to `COLUMN-MAJOR` after fortran touched it.