### PR TITLE
Ask gfortran 10 to take it easy

### DIFF
--- a/magicl-transcendental.asd
+++ b/magicl-transcendental.asd
@@ -26,7 +26,7 @@
                                          :defaults fortran-file)))
       (uiop:run-program
        (list "gfortran" "-fPIC" "-std=legacy"
-	     "-c"
+             "-c"
              (nn fortran-file)
              "-o"
              (nn object-file)))
@@ -59,4 +59,3 @@
                  (:file "load-libs")
                  (:file "transcendental")))
    (:file "src/bindings/expokit-cffi")))
-

--- a/magicl-transcendental.asd
+++ b/magicl-transcendental.asd
@@ -25,7 +25,8 @@
                                          :name "libexpokit"
                                          :defaults fortran-file)))
       (uiop:run-program
-       (list "gfortran" "-fPIC" "-c"
+       (list "gfortran" "-fPIC" "-std=legacy"
+	     "-c"
              (nn fortran-file)
              "-o"
              (nn object-file)))


### PR DESCRIPTION


A fresh `(ql:quickload :magicl-tests)` failed for me today when trying to compile `magicl/transcendental/expokit.f` with gfortran 10.2.0. Peeking at the error, I see

```
...

  294 |          call DNCHBV(mx,sgn*t_step,wsp(ih),mh,wsp(iexph),wsp(ifree+mx))
      |                                                                        1
Error: Type mismatch in argument 'wsp' at (1); passed REAL(8) to COMPLEX(8)
/Users/erik/.quicklisp/dists/quicklisp/software/magicl-v0.7.0/transcendental/expokit.f:1901:72:

 1901 |          call DNCHBV(mx,sgn*t_step,wsp(ih),mh,wsp(iexph),wsp(ifree+mx))
      |                                                                        1
Error: Type mismatch in argument 'wsp' at (1); passed REAL(8) to COMPLEX(8)
/Users/erik/.quicklisp/dists/quicklisp/software/magicl-v0.7.0/transcendental/expokit.f:2283:72:

 2283 |          call DNCHBV(mx,sgn*t_step,wsp(ih),mh,wsp(iexph),wsp(ifree+mx))
      |                                                                        1
Error: Type mismatch in argument 'wsp' at (1); passed REAL(8) to COMPLEX(8)
```

This seems to be something that previous versions of gfortran ignored. From the [GCC 10 Release Notes](https://gcc.gnu.org/gcc-10/changes.html)

> Mismatches between actual and dummy argument lists in a single file are now rejected with an error. Use the new option -fallow-argument-mismatch to turn these errors into warnings; this option is implied with -std=legacy. -Wargument-mismatch has been removed.

I'm preferring to use `-std=legacy`, since it works on earlier versions of gfortran.