### PR TITLE
Allow for rectangular matrices in QR, QL, RQ, LQ factorizations.

### DIFF
--- a/examples.lisp
+++ b/examples.lisp
@@ -74,7 +74,7 @@
       (assert (magicl:= a a-reconst)))))
 
 (defun rq-printing (a)
-  (multiple-value-bind (q r)
+  (multiple-value-bind (r q)
       (magicl:rq a)
     (format t "A~%~a~%" a)
     (format t "Q~%~a~%" q)
@@ -84,7 +84,7 @@
       (assert (magicl:= a a-reconst)))))
 
 (defun lq-printing (a)
-  (multiple-value-bind (q l)
+  (multiple-value-bind (l q)
       (magicl:lq a)
     (format t "A~%~a~%" a)
     (format t "Q~%~a~%" q)

--- a/src/high-level/matrix.lisp
+++ b/src/high-level/matrix.lisp
@@ -401,43 +401,43 @@ If fast is t then just change layout. Fast can cause problems when you want to m
               (setq d (- d))))
           d)))))
 
-(defgeneric upper-triangular (matrix &optional order)
-  (:documentation "Get the upper triangular portion of the matrix")
-  (:method ((matrix matrix) &optional (order (ncols matrix)))
-    (assert-square-matrix matrix)
+(defgeneric upper-triangular (matrix &key square)
+  (:documentation "Get the upper triangular portion of the matrix.
+
+If :SQUARE is T, then the result will be restricted to the upper rightmost square submatrix of the input.")
+  (:method ((matrix matrix) &key square)
     (let ((m (nrows matrix))
           (n (ncols matrix)))
-      (policy-cond:with-expectations (> speed safety)
-          ((assertion (<= order (max (nrows matrix) (ncols matrix)))))
-        (let ((target (empty (list order order) :layout (layout matrix) :type (element-type matrix))))
-          (if (> m n)
-              (loop for i from 0 to (1- order)
-                    do (loop for j from (max 0 (+ (- n order) i)) to (1- n)
-                             do (setf (tref target i (+ j (- order n))) (tref matrix i j))))
-              (loop for j from (- n order) to (1- n)
-                    do (loop for i from 0 to (min (+ (- order n) j) (1- m))
-                             do (setf (tref target i (- j (- n order))) (tref matrix i j)))))
-          target)))))
+      (let* ((end-i (if square (min m n) m))
+             (start-j (if square (- n end-i) 0))
+             (target (empty (list end-i (- n start-j))
+                            :layout (layout matrix) :type (element-type matrix))))
+        (loop :for i :below end-i
+              :do (loop :for j :from (+ start-j i) :below n
+                        :for j0 :from i
+                        :do (setf (tref target i j0)
+                                  (tref matrix i j))))
+        target))))
 ;;; Synonym for upper-triangular
 (setf (fdefinition 'triu) #'upper-triangular)
 
-(defgeneric lower-triangular (matrix &optional order)
-  (:documentation "Get the lower triangular portion of the matrix")
-  (:method ((matrix matrix) &optional (order (ncols matrix)))
-    (assert-square-matrix matrix)
+(defgeneric lower-triangular (matrix &key square)
+  (:documentation "Get the lower triangular portion of the matrix.
+
+If :SQUARE is T, then the result will be restricted to the lower leftmost square submatrix of the input.")
+  (:method ((matrix matrix) &key square)
     (let ((m (nrows matrix))
           (n (ncols matrix)))
-      (policy-cond:with-expectations (> speed safety)
-          ((assertion (<= order (max (nrows matrix) (ncols matrix)))))
-        (let ((target (empty (list order order) :layout (layout matrix) :type (element-type matrix))))
-          (if (> m n)
-              (loop for i from (- m order) to (1- m)
-                    do (loop for j from 0 to (min (+ (- order m) i) (1- n))
-                             do (setf (tref target (- i (- m order)) j) (tref matrix i j))))
-              (loop for j from 0 to (1- order)
-                    do (loop for i from (max 0 (+ (- m order) j)) to (1- m)
-                             do (setf (tref target (+ i (- order m)) j) (tref matrix i j)))))
-          target)))))
+      (let* ((end-j (if square (min m n) n))
+             (start-i (if square (- m end-j) 0))
+             (target (empty (list (- m start-i) end-j)
+                            :layout (layout matrix) :type (element-type matrix))))
+        (loop :for j :below end-j
+              :do (loop :for i :from (+ start-i j) :below m
+                        :for i0 :from j
+                        :do (setf (tref target i0 j)
+                                  (tref matrix i j))))
+        target))))
 ;;; Synonym for lower-triangular
 (setf (fdefinition 'tril) #'lower-triangular)
 
@@ -523,29 +523,33 @@ If fast is t then just change layout. Fast can cause problems when you want to m
     (error "SVD is not defined for the generic matrix type.")))
 
 (defgeneric qr (matrix)
-  (:documentation "Finds the QL factorization of the matrix M. Returns two tensors (Q, R)
-NOTE: Only square matrices supported")
+  (:documentation "Finds the QR factorization of MATRIX. Returns two matrices (Q, R).
+
+NOTE: If MATRIX is not square, this will compute the reduced QR factoriation.")
   (:method ((matrix matrix))
     (declare (ignore matrix))
     (error "QR is not defined for the generic matrix type.")))
 
 (defgeneric ql (matrix)
-  (:documentation "Finds the QL factorization of the matrix M. Returns two tensors (Q, L)
-NOTE: Only square matrices supported")
+  (:documentation "Finds the QL factorization of MATRIX. Returns two matrices (Q, L).
+
+NOTE: If MATRIX is not square, this will compute the reduced QL factoriation.")
   (:method ((matrix matrix))
     (declare (ignore matrix))
     (error "QL is not defined for the generic matrix type.")))
 
 (defgeneric rq (matrix)
-  (:documentation "Finds the RQ factorization of the matrix M. Returns two tensors (R, Q)
-NOTE: Only square matrices supported")
+  (:documentation "Finds the RQ factorization of MATRIX. Returns two matrices (R, Q).
+
+NOTE: If MATRIX is not square, this will compute the reduced RQ factoriation.")
   (:method ((matrix matrix))
     (declare (ignore matrix))
     (error "RQ is not defined for the generic matrix type.")))
 
 (defgeneric lq (matrix)
-  (:documentation "Finds the LQ factorization of the matrix M. Returns two tensors (L, Q)
-NOTE: Only square matrices supported")
+  (:documentation "Finds the LQ factorization of MATRIX. Returns two matrices (L, Q).
+
+NOTE: If MATRIX is not square, this will compute the reduced LQ factoriation.")
   (:method ((matrix matrix))
     (declare (ignore matrix))
     (error "LQ is not defined for the generic matrix type.")))

--- a/tests/high-level-tests.lisp
+++ b/tests/high-level-tests.lisp
@@ -191,3 +191,20 @@
           :for reference-root :in reference-roots
           :for relative-error-tolerance :in relative-error-tolerances :do
             (is (< (abs (/ (- root reference-root) reference-root)) relative-error-tolerance)))))
+
+
+(deftest test-rectangular-factorizations ()
+  "Check that we can do various orthogonal factorizations for nonsquare matrices."
+  (let ((tall (magicl:rand '(10 4)))
+        (fat (magicl:rand '(4 10))))
+    (dolist (factorization (list #'magicl:qr #'magicl:ql))
+      (multiple-value-bind (a b)
+          (funcall factorization tall)
+        (is (magicl:= (magicl:@ a b) tall)))
+      (signals error (funcall factorization fat)))
+
+    (dolist (factorization (list #'magicl:rq #'magicl:lq))
+      (multiple-value-bind (a b)
+          (funcall factorization fat)
+        (is (magicl:= (magicl:@ a b) fat)))
+      (signals error (funcall factorization tall)))))


### PR DESCRIPTION
This allows for non-square matrices in these routines, e.g.
```
MAGICL> (qr (rand '(4 2)))
#<MATRIX/DOUBLE-FLOAT (4x2):
   0.551     0.151
   0.137     0.808
   0.659     0.122
   0.493    -0.556>
#<MATRIX/DOUBLE-FLOAT (2x2):
   1.310     1.189
   0.000     0.857>
```
This also addresses #78. The previous `order` business was a bit too confusing imo. The key thing that's needed for working with LAPACK is to extract upper/lower square submatrices. If we had slices, I would have used those, but for now I've just added a `:square` flag. This follows the LAPACK convention: when enabled, `upper-triangular` takes the upper rightmost square submatrix, and `lower-triangular` takes the lower leftmost, e.g.

```
MAGICL> (from-list '(1 2 3 4 5 6) '(2 3))
#<MATRIX/INT32 (2x3):
    1      2      3
    4      5      6>
MAGICL> (upper-triangular (from-list '(1 2 3 4 5 6) '(2 3)))
#<MATRIX/INT32 (2x3):
    1      2      3
    0      5      6>
MAGICL> (upper-triangular (from-list '(1 2 3 4 5 6) '(2 3)) :square t)
#<MATRIX/INT32 (2x2):
    2      3
    0      6>
```