### PR TITLE
WIP: Add block matrix routines

### DIFF
--- a/src/high-level/matrix.lisp
+++ b/src/high-level/matrix.lisp
@@ -292,26 +292,91 @@ ELEMENT-TYPE, CAST, COPY-TENSOR, DEEP-COPY-TENSOR, TREF, SETF TREF)"
     (reduce #'mult matrices
             :initial-value matrix)))
 
+;;; Block matrices
+
+(defun block-diag (mat &rest blocks)
+  "Construct a block diagonal matrix, given blocks (MAT . BLOCKS)."
+  (push mat blocks)
+  (let ((nrows 0)
+        (ncols 0)
+        (type (element-type mat)))
+    (dolist (mat blocks)
+      (incf nrows (nrows mat))
+      (incf ncols (ncols mat))
+      ;; TODO: type coercion? for now we can be strict
+      (unless (equalp type (element-type mat))
+               (error "Unable to construct block matrix from blocks with disagreeing types.")))
+    (let ((result (zeros (list nrows ncols) :type type)))
+      (loop :with i := 0
+            :with j := 0
+            :for mat :in blocks
+            :do (slice-to mat (list 0 0) (shape mat) result (list i j))
+                (incf i (nrows mat))
+                (incf j (ncols mat)))
+      result)))
+
+(defun hstack (mat &rest matrices)
+  "Concatenate matrices 'horizontally' (column wise)."
+  (push mat matrices)
+  (let* ((rows (nrows mat))
+         (type (element-type mat))
+         (cols
+           (loop :for mat :in matrices
+                 :unless (cl:= rows (nrows mat))
+                   :do (error "Matrices have conflicting number of rows: ~D vs ~D." rows (nrows mat))
+                 :unless (eq type (element-type mat))
+                   :do (error "Matrices have conflicting types: ~A vs ~A." type (element-type mat))
+                 :summing (ncols mat))))    
+    (loop :with result := (zeros (list rows cols) :type type)
+          :with j := 0
+          :for mat :in matrices
+          :do (slice-to mat (list 0 0) (shape mat) result (list 0 j))
+          :do (incf j (ncols mat))
+          :finally (return result))))
+
+(defun vstack (mat &rest matrices)
+  "Concatenate matrices 'vertically' (row wise)."
+  (push mat matrices)
+  (let* ((cols (ncols mat))
+         (type (element-type mat))
+         (rows
+           (loop :for mat :in matrices
+                 :unless (cl:= cols (ncols mat))
+                   :do (error "Matrices have conflicting number of columns: ~D vs ~D." cols (ncols mat))
+                 :unless (eq type (element-type mat))
+                   :do (error "Matrices have conflicting types: ~A vs ~A." type (element-type mat))
+                 :summing (nrows mat))))    
+    (loop :with result := (zeros (list rows cols) :type type)
+          :with i := 0
+          :for mat :in matrices
+          :do (slice-to mat (list 0 0) (shape mat) result (list i 0))
+          :do (incf i (nrows mat))
+          :finally (return result))))
+
+(defun block-matrix (blocks shape)
+  "Construct a matrix from a list of blocks. Here SHAPE denotes the number of blocks in each row and column."
+  (let ((len (length blocks)))
+    (policy-cond:with-expectations (> speed safety)
+        ((type shape shape)
+         (assertion (cl:= 2 (length shape)))
+         (assertion (cl:= len (reduce #'* shape))))
+      (let ((block-rows
+              (loop :with ncols := (second shape)
+                    :and tail := blocks
+                    :while tail
+                    :collect (apply #'hstack
+                                    (loop :for elts :on tail
+                                          :for i :below ncols
+                                          :collect (first elts)
+                                          :finally (setf tail elts))))))
+        (apply #'vstack block-rows)))))
+
 ;;; Generic matrix methods
 
 (defgeneric direct-sum (a b)
   (:method ((a matrix) (b matrix))
     "Compute the direct sum of A and B"
-    (let* ((arows (nrows a))
-           (acols (ncols a))
-           (brows (nrows b))
-           (bcols (ncols b))
-           (rrows (+ arows brows))
-           (rcols (+ acols bcols))
-           (result (magicl:empty (list rrows rcols)
-                                 :type '(complex double-float))))
-      (loop :for r :below arows :do
-        (loop :for c :below acols :do
-          (setf (tref result r c) (tref a r c))))
-      (loop :for r :from arows :below rrows :do
-        (loop :for c :from acols :below rcols :do
-          (setf (tref result r c) (tref b (- r arows) (- c acols)))))
-      result)))
+    (block-diag a b)))
 
 (defgeneric kron (a b &rest rest)
   (:documentation "Compute the Kronecker product of A and B")

--- a/src/packages.lisp
+++ b/src/packages.lisp
@@ -76,6 +76,7 @@
 
            #:reshape
            #:slice
+           #:slice-to
            
            ;; Classes
            #:tensor
@@ -113,6 +114,12 @@
            #:ones
 
            #:random-unitary
+
+           ;; Block matrix construction
+           #:block-diag
+           #:hstack
+           #:vstack
+           #:block-matrix
 
            ;; Operators
            #:binary-operator

--- a/tests/matrix-tests.lisp
+++ b/tests/matrix-tests.lisp
@@ -151,3 +151,42 @@
              (magicl:eye (list i i) :type type)
              (magicl:@ m (magicl:transpose m))
              5e-5))))))
+
+(deftest test-block-diagonal ()
+  "Test that we can construct block diagonal matrices."
+  (let ((expected (magicl:from-list '(0d0 0d0 0d0
+                                      0d0 1d0 1d0
+                                      0d0 1d0 1d0)
+                                    '(3 3))))
+    (is (magicl:= expected
+                  (magicl::block-diag (magicl:zeros '(1 1)) (magicl:ones '(2 2)))))))
+
+(deftest test-matrix-stacking ()
+  "Test that we can stack matrices 'horizontally' and 'vertically'."
+  (let ((expected (magicl:from-list '(1 2 3
+                                      4 5 6)
+                                    '(2 3))))
+    (is (magicl:= expected
+                  (apply #'magicl::hstack
+                         (loop :for j :below 3
+                               :collect (magicl:column expected j)))))
+    (is (magicl:= expected
+                  (apply #'magicl::vstack
+                         (loop :for i :below 2
+                               :collect (magicl:row expected i)))))))
+
+
+(deftest test-block-matrix-construction ()
+  "Test that we can construct a block matrix."
+  (let ((mat
+          (magicl::block-matrix (list (magicl:zeros '(3 2))     (magicl:eye 3 :value 3d0)
+                                      (magicl:eye 2 :value 2d0)     (magicl:zeros '(2 3)))
+                                '(2 2))))
+    (is (magicl:=
+         mat
+         (magicl:from-list '(0d0 0d0 3d0 0d0 0d0
+                             0d0 0d0 0d0 3d0 0d0
+                             0d0 0d0 0d0 0d0 3d0
+                             2d0 0d0 0d0 0d0 0d0
+                             0d0 2d0 0d0 0d0 0d0)
+                           '(5 5))))))


### PR DESCRIPTION
I think it would be convenient to have an interface for working with block matrices. As a first pass at this, I've drafted up implementations of a few routines:

- `block-diag` is like `diag`, but takes matrices
- `hstack` and `vstack` are functions similar to what is found in Numpy (e.g. https://numpy.org/doc/stable/reference/generated/numpy.hstack.html) for concatenating matrices "horizontally" or "vertically"
- `block-matrix` is like `from-list`, but the entries of the list are blocks
- `slice-to` is just a variant of `slice` which allows one to specify where to write the results to. This reduces the need for intermediate allocations, although this would potentially be deprecated by whatever comes out of https://github.com/rigetti/magicl/issues/83

I can imagine in principle a few more, e.g. routines for decomposing a matrix into blocks (sort of an inverse to `block-matrix`, where you would provide block sizes and get back a list of blocks), although I haven't included this because `submatrix` is convenient enough for my immediate work.

cc: @stylewarning @notmgsk @colescott 