### PR TITLE
Fix handling of matrix layout in PTR-REF and LAPACK-CSD

### DIFF
--- a/src/high-level/matrix.lisp
+++ b/src/high-level/matrix.lisp
@@ -262,8 +262,10 @@ ELEMENT-TYPE, CAST, COPY-TENSOR, DEEP-COPY-TENSOR, TREF, SETF TREF)"
     (policy-cond:with-expectations (> speed safety)
         ((assertion (valid-index-p (list i j) (shape m))))
       (let ((type (element-type m)))
-        ;; TODO: compensate for layout
-        (let ((idx (apply #'matrix-column-major-index i j (shape m))))
+        (let ((idx (apply (ecase (layout m)
+                            (:column-major #'matrix-column-major-index)
+                            (:row-major #'matrix-row-major-index))
+                          i j (shape m))))
           (cond
             ((subtypep type 'single-float) (cffi:mem-aptr base :float idx))
             ((subtypep type 'double-float) (cffi:mem-aptr base :double idx))

--- a/src/high-level/types/complex-double-float.lisp
+++ b/src/high-level/types/complex-double-float.lisp
@@ -129,7 +129,7 @@
           (jobv1t "Y")
           (jobv2t "Y")
           (trans 
-            (if (eql :row-major layout)
+            (if (eq :row-major layout)
                 "T"
                 "F"))
           (signs "D")
@@ -188,10 +188,10 @@
                              x11 ldx11 x12 ldx12 x21 ldx21 x22 ldx22
                              theta u1 ldu1 u2 ldu2 v1t ldv1t v2t ldv2t
                              work lwork rwork lrwork iwork info)
-          (values (from-array u1 (list p p) :input-layout :column-major)
-                  (from-array u2 (list (- m p) (- m p)) :input-layout :column-major)
-                  (from-array v1t (list q q) :input-layout :column-major)
-                  (from-array v2t (list (- m q) (- m q)) :input-layout :column-major)
+          (values (from-array u1 (list p p) :input-layout layout)
+                  (from-array u2 (list (- m p) (- m p)) :input-layout layout)
+                  (from-array v1t (list q q) :input-layout layout)
+                  (from-array v2t (list (- m q) (- m q)) :input-layout layout)
                   (coerce theta 'list)))))))
 
 (defmethod csd-2x2-basic ((unitary-matrix-2x2 matrix/complex-double-float) p q)


### PR DESCRIPTION
This fixes a bug where `LAPACK-CSD` gives the wrong values for row-major matrices.

In previous versions of magicl, matrices constructed with `FROM-ARRAY` had their layout determined by the layout of the input array, and so essentially all matrices had `:column-major` by default. More recent changes f761ef92410e155886b70649abf1c29b8cb6ddd7 allow this to be controlled by a keyword argument of `FROM-ARRAY`, and the default was changed to `:row-major`. Unfortunately `LAPACK-CSD` did not handle this correctly for two reasons:


- `:column-major` input layout was hardcoded by default in `LAPACK-CSD`
- The actual code responsible for dereferencing pointers for the underlying lapack library, `PTR-REF`, was incomplete.

This issue was not exercised by `magicl-tests`, but does come up in `cl-quil-tests::compiler-hook-tests`. We fix these and add a new test for `LAPACK-CSD` in `magicl-tests`.

This also suggests a change to the general magicl PR workflow: in addition to ensuring that magicl tests pass, we should also be routinely running cl-quil tests against the updated versions for magicl. 

cc: @notmgsk @stylewarning 