### PR TITLE
Speed up some operations with vectors and matrices

### DIFF
--- a/magicl.asd
+++ b/magicl.asd
@@ -53,5 +53,6 @@
                  (:file "lapack-bindings")
                  (:file "constructors")
                  (:file "specialize-constructor")
-                 (:file "polynomial-solver")))
+                 (:file "polynomial-solver")
+                 (:file "blas-bindings")))
    (:file "magicl")))

--- a/src/high-level/abstract-tensor.lisp
+++ b/src/high-level/abstract-tensor.lisp
@@ -125,15 +125,15 @@ If LAYOUT is specified then traverse TENSOR in the specified order (column major
       (foreach (lambda (x) (incf sum x)) tensor)
       sum)))
 
-(defgeneric scale (tensor factor)
-  (:documentation "Scale TENSOR by FACTOR, returning a new tensor of the same type as TENSOR")
-  (:method ((tensor abstract-tensor) (factor number))
-    (map! (lambda (x) (* x factor)) (deep-copy-tensor tensor))))
-
 (defgeneric scale! (tensor factor)
   (:documentation "Scale TENSOR by FACTOR, storing back into the tensor")
   (:method ((tensor abstract-tensor) (factor number))
     (map! (lambda (x) (* x factor)) tensor)))
+
+(defgeneric scale (tensor factor)
+  (:documentation "Scale TENSOR by FACTOR, returning a new tensor of the same type as TENSOR")
+  (:method ((tensor abstract-tensor) (factor number))
+    (scale! (deep-copy-tensor tensor) factor)))
 
 (defgeneric slice (tensor from to)
   (:documentation "Slice a tensor from FROM to TO, returning a new tensor with the contained elements")

--- a/src/high-level/blas-bindings.lisp
+++ b/src/high-level/blas-bindings.lisp
@@ -1,0 +1,159 @@
+;;;; blas-bindings.lisp
+;;;;
+;;;; Author: Vasily Postnicov
+
+(in-package #:magicl)
+
+;; Map can be done on underlying array
+;; FIXME: beware of side effects!
+;; FIXME: Can we just specialize on abstact-tensor?
+(macrolet ((def-map! (type)
+             `(defmethod map! ((function function)
+                               (tensor ,type))
+                (map-into
+                 (storage tensor)
+                 function
+                 (storage tensor))
+                tensor)))
+  (def-map! matrix)
+  (def-map! vector))
+
+;; Scalar - matrix multiplication
+(macrolet ((def-scale (matrix-type scalar-type function)
+             `(defmethod scale! ((tensor ,matrix-type)
+                                 (factor ,scalar-type))
+                (,function
+                 (size tensor)
+                 factor
+                 (storage tensor)
+                 1)
+                tensor)))
+  (def-scale matrix/single-float single-float magicl.blas-cffi:%sscal)
+  (def-scale matrix/double-float double-float magicl.blas-cffi:%dscal)
+  (def-scale vector/single-float single-float magicl.blas-cffi:%sscal)
+  (def-scale vector/double-float double-float magicl.blas-cffi:%dscal))
+
+(declaim (inline compatible-matrices-p
+                 compatible-vectors-p))
+(defun compatible-matrices-p (m1 m2)
+  (and
+   (eq (matrix-layout m1)
+       (matrix-layout m2))
+   (eq (type-of m1)
+       (type-of m2))))
+
+(defun compatible-vectors-p (v1 v2)
+  (eq (type-of v1)
+      (type-of v2)))
+
+(defmacro with-compatibility-test ((tensor-type) &body body)
+  `(cond
+     (,(if (subtypep tensor-type 'matrix)
+           `(and (compatible-matrices-p source1 source2)
+                 (or (not target) (compatible-matrices-p source1 target)))
+           `(or (not target) (compatible-vectors-p source1 target)))
+      ,@body)
+     (t (call-next-method))))
+
+(defgeneric copy-to/w-same-layout (source target)
+  (:documentation "Fast copy from SOURCE to TARGET with the same
+layout. If TARGET is NIL, this function works just like
+DEEP-COPY-TENSOR."))
+
+(defmethod copy-to/w-same-layout ((source abstract-tensor)
+                                  (target null))
+  (deep-copy-tensor source))
+
+(macrolet ((def-copier (tensor-type scalar-type)
+             `(defmethod copy-to/w-same-layout ((source ,tensor-type)
+                                                (target ,tensor-type))
+                (declare (optimize (speed 3)))
+                (when (not (eq source target))
+                  (let ((storage-t (storage target))
+                        (storage-s (storage source)))
+                    (declare (type (simple-array ,scalar-type)
+                                   storage-s storage-t))
+                    (map-into storage-t #'identity storage-s)))
+                target)))
+  (def-copier matrix/single-float single-float)
+  (def-copier matrix/double-float double-float)
+  (def-copier vector/single-float single-float)
+  (def-copier vector/double-float double-float))
+
+;; Fast matrix/vector addition
+(macrolet ((def-+ (tensor-type scalar-type function)
+             `(defmethod .+ ((source1 ,tensor-type)
+                             (source2 ,tensor-type)
+                             &optional target)
+                (with-compatibility-test (,tensor-type)
+                  (policy-cond:with-expectations (> speed safety)
+                      ((assertion (equalp (shape source1)
+                                          (shape source2)))))
+                  (let ((source1 (if (eq target source1)
+                                     (deep-copy-tensor source1)
+                                     source1))
+                        (source2 (copy-to/w-same-layout source2 target)))
+                    (,function
+                     (size source2)
+                     (coerce 1 ',scalar-type)
+                     (storage source1) 1
+                     (storage source2) 1)
+                    source2)))))
+  (def-+ matrix/single-float single-float magicl.blas-cffi:%saxpy)
+  (def-+ matrix/double-float double-float magicl.blas-cffi:%daxpy)
+  (def-+ vector/single-float single-float magicl.blas-cffi:%saxpy)
+  (def-+ vector/double-float double-float magicl.blas-cffi:%daxpy))
+
+;; Fast matrix/vector subtraction
+(macrolet ((def-- (tensor-type scalar-type function)
+             `(defmethod .- ((source1 ,tensor-type)
+                             (source2 ,tensor-type)
+                             &optional target)
+                (with-compatibility-test (,tensor-type)
+                  (policy-cond:with-expectations (> speed safety)
+                      ((assertion (equalp (shape source1)
+                                          (shape source2)))))
+                  (let ((source2 (if (eq target source2)
+                                     (deep-copy-tensor source2)
+                                     source2))
+                        (source1 (copy-to/w-same-layout source1 target)))
+                    (,function
+                     (size source2)
+                     (coerce -1 ',scalar-type)
+                     (storage source2) 1
+                     (storage source1) 1)
+                    source1)))))
+  (def-- matrix/single-float single-float magicl.blas-cffi:%saxpy)
+  (def-- matrix/double-float double-float magicl.blas-cffi:%daxpy)
+  (def-- vector/single-float single-float magicl.blas-cffi:%saxpy)
+  (def-- vector/double-float double-float magicl.blas-cffi:%daxpy))
+
+;; Fast matrix/vector element-wise multiplication/division
+
+(macrolet ((def-op (name tensor-type scalar-type function)
+             `(defmethod ,name ((source1 ,tensor-type)
+                                (source2 ,tensor-type)
+                                &optional target)
+                (declare (optimize (speed 3)))
+                (with-compatibility-test (,tensor-type)
+                  (policy-cond:with-expectations (> speed safety)
+                      ((assertion (equalp (shape source1)
+                                          (shape source2)))))
+                  (let ((target
+                          (or target
+                              (empty (shape source1) :type ',scalar-type))))
+                    (let ((target-st  (storage target))
+                          (source1-st (storage source1))
+                          (source2-st (storage source2)))
+                      (declare (type (simple-array ,scalar-type)
+                                     target-st source1-st source2-st))
+                      (map-into target-st #',function source1-st source2-st))
+                    target)))))
+  (def-op .* matrix/single-float single-float *)
+  (def-op .* matrix/double-float double-float *)
+  (def-op ./ matrix/single-float single-float /)
+  (def-op ./ matrix/double-float double-float /)
+  (def-op .* vector/single-float single-float *)
+  (def-op .* vector/double-float double-float *)
+  (def-op ./ vector/single-float single-float /)
+  (def-op ./ vector/double-float double-float /))


### PR DESCRIPTION
Hi! I had a [conversation](https://twitter.com/stylewarning/status/1370438701541584899) with @stylewarning on Twitter and he suggested me to share my modifications to `magicl` used in my `neural-classifier` library.

These modifications speed up `magicl:scale`, `magicl:.+`, `magicl:.-`, `magicl:.*`, `magicl:./` and `magicl:map` functions when applied to single- and double-precision vectors or matrices. In `neural-classifier` I need those functions only for `matrix/single-float` type, but I've made an attempt to generalize them to other types.

As I told in Twitter this is not an easy task. For example, I am not sure if my method for `magicl:map!` will work as the most general method if the supplied function produces side effects because the order the items are traversed may not be the same.

Moreover, all arguments for arithmetic functions must be of the same type and layout or the result will be incorrect. This is covered in `with-compatibility-test` macro which calls the next method if this method cannot be applied.

There can be other corner cases in which these method may not work. I think I need to add tests to cover them all, but now I am drained :) Firstly, I'd like to hear if this work is needed at all.

Here are some time measurements.

Before:  
![20210313_11h29m14s_grim](https://user-images.githubusercontent.com/812069/111025042-e8715d80-83f2-11eb-8513-70a684c14684.png)

After:  
![20210313_11h31m15s_grim](https://user-images.githubusercontent.com/812069/111025039-e5766d00-83f2-11eb-93cd-db068e67333f.png)