### PR TITLE
add EVAL-WHEN around compile-time-needed definitions

### DIFF
--- a/src/backend-function.lisp
+++ b/src/backend-function.lisp
@@ -90,25 +90,31 @@ Without using this, a backend function may error if no method is found."
 
 ;;; Backend Names
 
-(defvar *known-backends* '()
-  "A list of known backends.")
+;;; Eval at compile-time because DEFINE-BACKEND and the DEFTYPE below
+;;; will need it for proper expansion later in the file.
+;;;
+;;; (h/t phoe 3/31/21)
+(eval-when (:compile-toplevel :load-toplevel :execute)
+  (defvar *known-backends* '()
+    "A list of known backends.")
 
-(defun backend-name-p (x)
-  (and (symbolp x)
-       (find x *known-backends*)
-       t))
-
-(deftype backend-name ()
-  '(satisfies backend-name-p))
-
-(defvar *backend* '()
-  "A list in priority order the backends that MAGICL should use for functionality.
+  (defvar *backend* '()
+    "A list in priority order the backends that MAGICL should use for functionality.
 
 It is preferable to use WITH-BACKENDS instead of this.")
+  
+  (defun backend-name-p (x)
+    (and (symbolp x)
+         (find x *known-backends*)
+         t))
+)                                       ; EVAL-WHEN
 
 (defun active-backends ()
   "Return a list of the active backends in priority order. Useful for debugging."
   *backend*)
+
+(deftype backend-name ()
+  '(satisfies backend-name-p))
 
 (defmacro define-backend (name &key documentation
                                     (default nil))


### PR DESCRIPTION
This is in response to [this build failure](http://report.quicklisp.org/2021-03-31/failure-report/magicl.html#magicl_ext-blas). I couldn't reproduce this on a 2.1.2 SBCL.

Some old SBCLs are erroring, probably\* because some compile-time-needed definitions (`defvar` and `defun`) are needed for a subsequent `deftype` and `defmacro`. SBCL has typically not been picky about this, but maybe it is in this tangle of definitions.

We fix by just adding an `eval-when` around these definitions.

Tests pass locally; not sure about Quicklisp or old SBCL.

\* I didn't actually download an ancient SBCL and test. This was a very likely hunch by `phoe` from `#lisp` on 3/31/21.